### PR TITLE
Made Lengow environment-urls configurable

### DIFF
--- a/Block/Adminhtml/Footer.php
+++ b/Block/Adminhtml/Footer.php
@@ -21,8 +21,8 @@ namespace Lengow\Connector\Block\Adminhtml;
 
 use Magento\Backend\Block\Template;
 use Magento\Backend\Block\Template\Context;
+use Lengow\Connector\Helper\Config as ConfigHelper;
 use Lengow\Connector\Helper\Security as SecurityHelper;
-use Lengow\Connector\Model\Connector as LengowConnector;
 
 class Footer extends Template
 {
@@ -32,18 +32,26 @@ class Footer extends Template
     private $securityHelper;
 
     /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
      * Constructor
      *
      * @param Context $context Magento block context instance
      * @param SecurityHelper $securityHelper Lengow security helper instance
+     * @param ConfigHelper $configHelper Lengow config helper instance
      * @param array $data additional params
      */
     public function __construct(
         Context $context,
         SecurityHelper $securityHelper,
+        ConfigHelper $configHelper,
         array $data = []
     ) {
         $this->securityHelper = $securityHelper;
+        $this->configHelper = $configHelper;
         parent::__construct($context, $data);
     }
 
@@ -64,7 +72,7 @@ class Footer extends Template
      */
     public function isPreprodPlugin(): string
     {
-        return LengowConnector::LENGOW_URL === 'lengow.net';
+        return !$this->configHelper->useProdEnvironment();
     }
 
     /**

--- a/Block/Adminhtml/Header.php
+++ b/Block/Adminhtml/Header.php
@@ -88,7 +88,7 @@ class Header extends Template
      */
     public function getLengowSolutionUrl(): string
     {
-        return '//my.' . LengowConnector::LENGOW_URL;
+        return '//my.' . $this->configHelper->getLengowDomain();
     }
 
     /**

--- a/Block/Adminhtml/Main.php
+++ b/Block/Adminhtml/Main.php
@@ -112,7 +112,7 @@ class Main extends Template
      */
     public function isPreprodPlugin(): bool
     {
-        return LengowConnector::LENGOW_URL === 'lengow.net';
+        return !$this->configHelper->useProdEnvironment();
     }
 
     /**
@@ -132,7 +132,7 @@ class Main extends Template
      */
     public function getLengowSolutionUrl(): string
     {
-        return '//my.' . LengowConnector::LENGOW_URL;
+        return '//my.' . $this->configHelper->getLengowDomain();
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -20,6 +20,7 @@
 namespace Lengow\Connector\Helper;
 
 use Exception;
+use Lengow\Connector\Model\Config\Source\Environment as EnvironmentSourceModel;
 use Magento\Catalog\Model\Product;
 use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory as ConfigDataCollectionFactory;
 use Magento\Customer\Model\ResourceModel\Group\CollectionFactory as CustomerGroupCollectionFactory;
@@ -42,7 +43,18 @@ use Magento\InventoryApi\Api\SourceRepositoryInterface;
 
 class Config extends AbstractHelper
 {
+    /**
+     * @var string domain of Lengow Pre-Prod environment
+     */
+    public const LENGOW_PRE_PROD_DOMAIN = 'lengow.net';
+
+    /**
+     * @var string domain of Lengow Prod environment
+     */
+    public const LENGOW_PROD_DOMAIN = 'lengow.io';
+
     /* Settings database key */
+    public const ENVIRONMENT = 'global_environment';
     public const ACCOUNT_ID = 'global_account_id';
     public const ACCESS_TOKEN = 'global_access_token';
     public const SECRET = 'global_secret_token';
@@ -116,6 +128,7 @@ class Config extends AbstractHelper
      * @var array params correspondence keys for toolbox
      */
     public static $genericParamKeys = [
+        self::ENVIRONMENT => 'environment',
         self::ACCOUNT_ID => 'account_id',
         self::ACCESS_TOKEN => 'access_token',
         self::SECRET => 'secret',
@@ -211,6 +224,12 @@ class Config extends AbstractHelper
      * @var array all Lengow options path
      */
     public static $lengowSettings = [
+        self::ENVIRONMENT => [
+            self::PARAM_PATH => 'lengow_global_options/store_credential/global_environment',
+            self::PARAM_GLOBAL => true,
+            self::PARAM_NO_CACHE => true,
+            self::PARAM_EXPORT => false,
+        ],
         self::ACCOUNT_ID => [
             self::PARAM_PATH => 'lengow_global_options/store_credential/global_account_id',
             self::PARAM_GLOBAL => true,
@@ -1120,6 +1139,34 @@ class Config extends AbstractHelper
             }
         }
         return $rows;
+    }
+
+    /**
+     * Returns whether prod-environment is configured to be used
+     * @return bool
+     */
+    public function useProdEnvironment(): bool
+    {
+        $configuredEnvironment = $this->get(self::ENVIRONMENT);
+
+        if ($configuredEnvironment === EnvironmentSourceModel::PROD_ENVIRONMENT) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns domain of the configured Lengow-environment
+     * @return string
+     */
+    public function getLengowDomain(): string
+    {
+        if ($this->useProdEnvironment()) {
+            return static::LENGOW_PROD_DOMAIN;
+        }
+
+        return self::LENGOW_PRE_PROD_DOMAIN;
     }
 
     /**

--- a/Model/Config/Source/Environment.php
+++ b/Model/Config/Source/Environment.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2022 Lengow SAS
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category    Lengow
+ * @package     Lengow_Connector
+ * @subpackage  Model
+ * @author      Team module <team-module@lengow.com>
+ * @copyright   2022 Lengow SAS
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+namespace Lengow\Connector\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class Environment implements OptionSourceInterface
+{
+    public const PRE_PROD_ENVIRONMENT = 'pre-prod';
+
+    public const PROD_ENVIRONMENT = 'prod';
+
+    /**
+     * @return array[]
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => static::PRE_PROD_ENVIRONMENT, 'label' => __('Pre-Prod')],
+            ['value' => static::PROD_ENVIRONMENT, 'label' => __('Prod')]
+        ];
+    }
+}

--- a/Model/Connector.php
+++ b/Model/Connector.php
@@ -29,18 +29,6 @@ use Lengow\Connector\Model\Import as LengowImport;
  */
 class Connector
 {
-    /**
-     * @var string url of Lengow solution
-     */
-    // const LENGOW_URL = 'lengow.io';
-    public const LENGOW_URL = 'lengow.net';
-
-    /**
-     * @var string url of the Lengow API
-     */
-    // const LENGOW_API_URL = 'https://api.lengow.io';
-    private const LENGOW_API_URL = 'https://api.lengow.net';
-
     /* Lengow API routes */
     public const API_ACCESS_TOKEN = '/access/get_token';
     public const API_ORDER = '/v3.0/orders';
@@ -551,7 +539,7 @@ class Connector
             $opts[CURLOPT_TIMEOUT] = $this->lengowUrls[$api];
         }
         // get base url for a specific environment
-        $url = self::LENGOW_API_URL . $api;
+        $url = $this->getLengowApiUrl() . $api;
         $opts[CURLOPT_CUSTOMREQUEST] = strtoupper($type);
         $url = parse_url($url);
         if (isset($url['port'])) {
@@ -651,5 +639,14 @@ class Connector
             case self::FORMAT_JSON:
                 return json_decode($data, true);
         }
+    }
+
+    /**
+     * Returns the url to the Lengow-api, considering configured environment
+     * @return string
+     */
+    private function getLengowApiUrl()
+    {
+        return 'https://api.' . $this->configHelper->getLengowDomain();
     }
 }

--- a/README.md
+++ b/README.md
@@ -74,11 +74,8 @@ Lengow for Magento 2 is available under license (OSL-3.0). If you want to contri
 The `master` branch contains the latest stable version of the plugin. The `dev` branch contains the version under development.
 All Pull requests must be made on the `dev` branch and must be validated by reviewers working at Lengow.
 
-By default the plugin is made to work on our pre-production environment (my.lengow.net).
-To change this environment, you must modify the two constants present in the file `Lengow/Connector/Model/Connector.php`
-
-    const LENGOW_URL = 'lengow.net';
-    const LENGOW_API_URL = 'https://api.lengow.net';
+By default, the plugin is made to work on our pre-production environment (my.lengow.net).
+The environment can be changed to production (my.lengow.io) in the settings of this module.
 
 ### Translation
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -13,6 +13,10 @@
             </group>
             <group id="store_credential" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="1">
                 <label>Identification settings</label>
+                <field id="global_environment" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Environment</label>
+                    <source_model>Lengow\Connector\Model\Config\Source\Environment</source_model>
+                </field>
                 <field id="global_account_id" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Account ID</label>
                     <comment>Your Lengow Account ID</comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,6 +3,7 @@
     <default>
         <lengow_global_options>
             <store_credential>
+                <global_environment>pre-prod</global_environment>
                 <global_store_enable>0</global_store_enable>
             </store_credential>
             <advanced>


### PR DESCRIPTION
As we are not able to change our code depending on the target system (Magento production- or test-server) we can not use different Lengow-modules for the different Lengow-environments.
In this change we implemented a Magento configuration that allows the selection of the Lengow environment (Pre-Prod or Prod). 
(Resolves #3) 