### PR TITLE
Fix trim error when customer firstname is empty

### DIFF
--- a/Model/Import/Customer.php
+++ b/Model/Import/Customer.php
@@ -620,8 +620,8 @@ class Customer extends MagentoResourceCustomer
     private function getNames($addressData): array
     {
         $names = [
-            'firstName' => trim($addressData->first_name),
-            'lastName' => trim($addressData->last_name),
+            'firstName' => empty($addressData->first_name) ? '' : trim($addressData->first_name),
+            'lastName' => empty($addressData->last_name) ? '' : trim($addressData->last_name),
             'fullName' => $this->cleanFullName($addressData->full_name),
         ];
         if (empty($names['lastName']) && empty($names['firstName'])) {


### PR DESCRIPTION
Hello,

I have the following error when I try to import the orders on a Magento 2.4.5-p1:
```
[Magento error]: "Deprecated Functionality: trim(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/lengow/module-connector/Model/Import/Customer.php on line 623" in vendor/magento/framework/App/ErrorHandler.php on line 62
```

This PR should fix it.

Thank you.