### PR TITLE
#45 Force token type to string

### DIFF
--- a/Controller/Export/Index.php
+++ b/Controller/Export/Index.php
@@ -165,6 +165,10 @@ class Index extends Action
             // translation now works
             $this->translate->loadData('frontend', true);
         }
+        // We need a string token, we do not accept anything else (can be null or array too at this point)
+        if (!is_string($token)) {
+            $token = '';
+        }
         if ($this->securityHelper->checkWebserviceAccess($token, $storeId)) {
             try {
                 // config store


### PR DESCRIPTION
Strong type error correction to avoid error :
- if the parameter is not given (null) 
- if an array parameter (token[]=1 for example)

Check https://github.com/lengow/plugin-magento2/issues/45 for description