### PR TITLE
misc(comments) : Some clarification on comments in Cron/LaunchResend.php

### DIFF
--- a/Cron/LaunchResend.php
+++ b/Cron/LaunchResend.php
@@ -82,7 +82,6 @@ class LaunchResend
      * @param StoreManagerInterface         $storeManager       Magento store manager instance
      * @param DataHelper                    $dataHelper         Lengow data helper instance
      * @param ConfigHelper                  $configHelper       Lengow config helper instance
-     * @param LengowExportFactory           $exportFactory      Lengow export factory instance
      * @param LengowOrderErrorFactory       $orderErrorFactory  Lengow order error factory
      * @param LengowOrderFactory            $lengowOrderFactory Lengow Order factory
      * @param MagentoOrderFactory           $orderFactory       Magento Order factory
@@ -107,7 +106,9 @@ class LaunchResend
     }
 
     /**
-     * Launch export products for each store
+     * Retrieves orders to be resent, and processes them
+     *
+     * @return void
      */
     public function execute(): void
     {


### PR DESCRIPTION
I was searching through the module to understand the product export process and I faced this function comment.
By reading the function code, I realized it has nothing to do with product anymore.

This is not really an issue but it's still nice to have relevant PHP comments just in case.

I also removed the function $exportFactory parameter line because the parameter does not exist anymore.