### PR TITLE
fix(import): fix case where an address would contain 3 street lines

### DIFF
--- a/Model/Import/Customer.php
+++ b/Model/Import/Customer.php
@@ -814,10 +814,10 @@ class Customer extends MagentoResourceCustomer
             $complement .= !empty($complement) ? ' - ' . $relayId : $relayId;
         }
         if (!empty($secondLine)) {
-            $street .= "\n" . $secondLine;
+            $street .= (strpos($street, "\n") === false ? "\n" : ', ') . $secondLine;
         }
         if (!empty($complement)) {
-            $street .= "\n" . $complement;
+            $street .= (strpos($street, "\n") === false ? "\n" : ', ') . $complement;
         }
         return strtolower($street);
     }


### PR DESCRIPTION
Fixed the following error
```
[Magento error]: ''Street Address' cannot contain more than 2 lines.' in [...]/vendor/magento/module-customer/Model/ResourceModel/Address.php on line 108
```
In case we have both a second line and a complement, the street have 3 lines which results in the error:
```
rue test
complement
relay id: 012345
```
If we already have a complement, the rest will be coma separated :
```
rue test
complement, relay id: 012345
```